### PR TITLE
Feature/4 live display

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -3,21 +3,18 @@ from __future__ import print_function
 
 import os
 import sys
-
-if sys.version_info >= (3, 0):
-    from configparser import SafeConfigParser, NoSectionError, NoOptionError
-else:
-    from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
-
-from subprocess import call, check_output, CalledProcessError, STDOUT
-if sys.version_info >= (3, 0):
-    from subprocess import getoutput
+import subprocess
 
 # requests might now be available. Don't run the "deploy" command in this case
 try:
     import requests
 except ImportError:
     pass
+
+if sys.version_info >= (3, 0):
+    from configparser import SafeConfigParser, NoSectionError, NoOptionError
+else:
+    from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
 
 working_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -55,10 +52,10 @@ class Deployer(object):
                 print('\n> ' + cmd)
                 return ''
             if sys.version_info >= (3, 0):
-                return getoutput(cmd)
+                return subprocess.getoutput(cmd)
             else:
-                return check_output(cmd.split(' '), stderr=STDOUT, cwd=working_dir if cwd is None else cwd)
-        except CalledProcessError as e:
+                return subprocess.check_output(cmd.split(' '), stderr=subprocess.STDOUT, cwd=working_dir if cwd is None else cwd)
+        except subprocess.CalledProcessError as e:
             if exceptions_should_bubble_up:
                 raise
             else:

--- a/deploy.py
+++ b/deploy.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 import sys
 import subprocess
+import shlex
 
 # requests might now be available. Don't run the "deploy" command in this case
 try:
@@ -47,14 +48,12 @@ class Deployer(object):
 
     def run(self, cmd, cwd=None, exceptions_should_bubble_up=False):
         """Run a shell command"""
+        if self.debug_mode:
+            print('\n> ' + cmd)
+            return ''
+
         try:
-            if self.debug_mode:
-                print('\n> ' + cmd)
-                return ''
-            if sys.version_info >= (3, 0):
-                return subprocess.getoutput(cmd)
-            else:
-                return subprocess.check_output(cmd.split(' '), stderr=subprocess.STDOUT, cwd=working_dir if cwd is None else cwd)
+            return subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT, cwd=working_dir if cwd is None else cwd)
         except subprocess.CalledProcessError as e:
             if exceptions_should_bubble_up:
                 raise

--- a/deploy.py
+++ b/deploy.py
@@ -88,6 +88,7 @@ class Deployer(object):
             return
         for char in string_to_escape:
             print('\b', end='')
+        print('\b', end='')
 
     def build(self, environment=develop, clean=False):
         """Build the image"""
@@ -100,27 +101,19 @@ class Deployer(object):
         proc = subprocess.Popen(args, stdout=subprocess.PIPE)
 
         step_count = None
-        first_run = True
         while True:
             line = proc.stdout.readline()
             if len(line) < 1:
                 break
             if 'Step ' in line:
+                self.backspace(step_count)
                 step_count = line.split(' : ')[0]
+                print('. ' + step_count, end='')
                 continue
-
-            display_char = None
             if 'Using cache' in line:
-                display_char = 'c'
-            if 'Running' in line:
-                display_char = '.'
-            if display_char is not None:
-                if first_run:
-                    first_run = False
-                else:
-                    self.backspace(step_count + ' ')
-                print(display_char + ' ' + step_count, end='')
-            continue
+                self.backspace(step_count + ' ')
+                print('c ' + step_count, end='')
+
         print(' OK')
 
     def cleanbuild(self, environment=develop):
@@ -201,7 +194,7 @@ class Deployer(object):
         try:
             output = self.run(cmd, exceptions_should_bubble_up=True).split("\n")
             self.printout(output)
-        except CalledProcessError as e:
+        except subprocess.CalledProcessError as e:
             self.printout("No messages found")
 
     def test(self):


### PR DESCRIPTION
This PR enables more interactive output for long-running commands. 

- The `build` command now displays live progress for each step, making the wait less painful
- The `test` command now prints the unit test output character by character instead of at a block, allowing developers to see failing and passing tests earlier
- Low-level, we introduce a new `spew` parameter, which causes the `run()` method to return a stream instead of a string. Callers can then access, parse, and live-display the stream.